### PR TITLE
feat: support kwargs

### DIFF
--- a/jinja2_shell_extension/__init__.py
+++ b/jinja2_shell_extension/__init__.py
@@ -9,13 +9,12 @@ except ImportError:
 
 
 @eval_context
-def shell(eval_ctx, value, die_on_error=False, encoding="utf8"):
+def shell(eval_ctx, value, die_on_error=False, encoding="utf8", **kwargs):
     if die_on_error:
         cmd = value
     else:
         cmd = "%s ; exit 0" % value
-    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
-    return output.decode(encoding)
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True, encoding=encoding, **kwargs)
 
 
 class ShellExtension(Extension):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -12,3 +12,9 @@ def test_extension1():
     template = env.from_string("test {{ \"whoami\"|shell }}")
     result = template.render()
     assert len(result) >= 6
+
+def test_input():
+    env = Environment(extensions=["jinja2_shell_extension.ShellExtension"])
+    template = env.from_string("{{ 'cat' | shell(input='meow', text=true) }}")
+    result = template.render()
+    assert result == "meow"


### PR DESCRIPTION
This gives more freedom to use the extension.

For example, as seen in the added test, you can pass some input to the command, which can then use it as its STDIN value.

@moduon MT-1075